### PR TITLE
fix(olm): preserve olm credentials on logout

### DIFF
--- a/Pangolin/Managers/AuthManager.swift
+++ b/Pangolin/Managers/AuthManager.swift
@@ -590,7 +590,6 @@ class AuthManager: ObservableObject {
 
         // Clear local data
         _ = secretManager.deleteSessionToken(userId: userId)
-        _ = secretManager.deleteOlmCredentials(userId: userId)
 
         accountManager.removeAccount(userId: userId)
 


### PR DESCRIPTION
## Community Contribution License Agreement
By creating this pull request, I grant the project maintainers an unlimited,
perpetual license to use, modify, and redistribute these contributions under any terms they
choose, including both the AGPLv3 and the Fossorial Commercial license terms. I
represent that I have the right to grant this license for all contributed content.

## Description

The recent multiple account support removed olm credentials on logout, which caused new devices to be created every single time a re-login was initiated. This is unintended, and the credentials should be kept when logging out. This PR removes the offending code.

## How to test?

Log out of the client, and re-login using the same credentials. A new device should not appear in the user list in the Pangolin dashboard, and the olm credentials that were generated previously should remain.
